### PR TITLE
secret keyが存在しない問題の修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN bundle install
 # アプリケーションのファイルをすべてコピー
 COPY . /app
 
-RUN RAILS_ENV=production bundle exec rails assets:precompile
+# RUN RAILS_ENV=production bundle exec rails assets:precompile
+RUN SECRET_KEY_BASE_DUMMY=1 RAILS_ENV=production bundle exec rails assets:precompile
 
 # ポート3001を公開
 EXPOSE 3001


### PR DESCRIPTION
secret keyが存在しないというエラーが出たので、ダミーを設置。
```
RUN SECRET_KEY_BASE_DUMMY=1 RAILS_ENV=production bundle exec rails assets:precompile
```
またrailwayのvariableからsecret key baseを削除master keyのみにする。